### PR TITLE
Window drag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ add_library(LilacStyle SHARED
     src/blur_manager.cpp
     src/animation_manager.cpp
     src/animation_manager.h
+    src/window_manager.cpp
+    src/window_manager.h
     src/utils/state.h
     src/utils/slider_focus_frame.cpp
     src/utils/slider_focus_frame.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option(NO_KSTYLE "Whether to not use KStyle" OFF)
 option(NO_KCOLORSCHEME "Whether to not use KColorScheme" OFF)
 option(NO_SETTINGS "Whether to not use KConfig and thus disabling runtime settings" OFF)
 option(NO_KWINDOWSYSTEM "Whether to not use KWindowSystem and thus disabling the ability to blur behind windows on supported platforms" OFF)
+option(NO_QTQUICK "Whether to not use QtQuick, disabling some integrations with QtQuick applications" OFF)
 
 find_package(Qt6 REQUIRED COMPONENTS Widgets Gui)
 
@@ -26,7 +27,11 @@ if(NOT NO_SETTINGS)
 endif()
 
 if(NOT NO_KWINDOWSYSTEM)
-    find_package(KF6WindowSystem  "6.5.0...<7.0.0" REQUIRED)
+    find_package(KF6WindowSystem "6.5.0...<7.0.0" REQUIRED)
+endif()
+
+if(NOT NO_QTQUICK)
+    find_package(Qt6 REQUIRED COMPONENTS Quick)
 endif()
 
 set(CMAKE_AUTOUIC ON)
@@ -136,6 +141,13 @@ if (NOT NO_KWINDOWSYSTEM)
     target_compile_definitions(LilacStyle PRIVATE HAS_KWINDOWSYSTEM=1)
 else()
     target_compile_definitions(LilacStyle PRIVATE HAS_KWINDOWSYSTEM=0)
+endif()
+
+if (NOT NO_QTQUICK)
+    target_link_libraries(LilacStyle PRIVATE Qt6::Quick)
+    target_compile_definitions(LilacStyle PRIVATE HAS_QTQUICK=1)
+else()
+    target_compile_definitions(LilacStyle PRIVATE HAS_QTQUICK=0)
 endif()
 
 target_compile_definitions(LilacStyle PRIVATE LILAC_LIBRARY)

--- a/README.md
+++ b/README.md
@@ -44,13 +44,21 @@ When enabled, two additional targets will be created, a standalone settings app 
 - **Available options**:
   `-DNO_SETTINGS=ON`: Disable settings
 
-#### KWindow System
+#### KWindowSystem
 
 [KWindowSystem](https://api.kde.org/kwindowsystem-index.html) is a library abstracting the window system. This style uses KWindowSystem to create a blur behind menus. Note that your system may not support this way of blurring behind windows/menus.
 
 - **Default behavior**: `OFF` (i.e. KWindowSystem will be included)
 - **Available options**:
   `-DNO_KWINDOWSYSTEM=ON`: Disable KWindowSystem
+
+#### Qt Quick
+
+[Qt Quick](https://doc.qt.io/qt-6/qtquick-index.html) is part of Qt, used to interface between C++ and Qt Quick applications. This style uses this library to allow Qt Quick windows to be dragged by their contents.
+
+- **Default behavior**: `OFF` (i.e. Qt Quick will be included)
+- **Available options**:
+  `-DNO_QTQUICK=ON`: Disable Qt Quick
 
 ### Installation steps:
 
@@ -63,30 +71,30 @@ When enabled, two additional targets will be created, a standalone settings app 
     _Build:_ `git` `cmake` `gcc-c++`
 
     _Run:_ <br>
-    `cmake(Qt6Widgets)` `cmake(Qt6Gui)`, KStyle:&nbsp;`cmake(KF6FrameworkIntegration)`, KColorScheme:&nbsp;`cmake(KF6ColorScheme)`, Settings:&nbsp;`cmake(KF6Config)` `cmake(Qt6DBus)`, KWindowSystem:&nbsp;`cmake(KF6WindowSystem)`
+    `cmake(Qt6Widgets)` `cmake(Qt6Gui)`, KStyle:&nbsp;`cmake(KF6FrameworkIntegration)`, KColorScheme:&nbsp;`cmake(KF6ColorScheme)`, Settings:&nbsp;`cmake(KF6Config)` `cmake(Qt6DBus)`, KWindowSystem:&nbsp;`cmake(KF6WindowSystem)`, Qt Quick:&nbsp;`cmake(Qt6Quick)`
 
     **OpenSUSE:**
 
     ```shell
-    sudo zypper in git cmake gcc-c++ 'cmake(Qt6Widgets)' 'cmake(Qt6Gui)' 'cmake(KF6FrameworkIntegration)' 'cmake(KF6ColorScheme)' 'cmake(KF6Config)' 'cmake(Qt6DBus)' 'cmake(KF6WindowSystem)'
+    sudo zypper in git cmake gcc-c++ 'cmake(Qt6Widgets)' 'cmake(Qt6Gui)' 'cmake(KF6FrameworkIntegration)' 'cmake(KF6ColorScheme)' 'cmake(KF6Config)' 'cmake(Qt6DBus)' 'cmake(KF6WindowSystem)' 'cmake(Qt6Quick)'
     ```
 
     **Fedora:**
 
     ```shell
-    sudo dnf install git cmake gcc-c++ 'cmake(Qt6Widgets)' 'cmake(Qt6Gui)' 'cmake(KF6FrameworkIntegration)' 'cmake(KF6ColorScheme)' 'cmake(KF6Config)' 'cmake(Qt6DBus)' 'cmake(KF6WindowSystem)'
+    sudo dnf install git cmake gcc-c++ 'cmake(Qt6Widgets)' 'cmake(Qt6Gui)' 'cmake(KF6FrameworkIntegration)' 'cmake(KF6ColorScheme)' 'cmake(KF6Config)' 'cmake(Qt6DBus)' 'cmake(KF6WindowSystem)' 'cmake(Qt6Quick)'
     ```
 
     **Ubuntu/Debian:**
 
     ```shell
-    sudo apt install git cmake g++ qt6-base-dev libkf6style-dev libkf6colorscheme-dev libkf6config-dev libkf6windowsystem-dev
+    sudo apt install git cmake g++ qt6-base-dev libkf6style-dev libkf6colorscheme-dev libkf6config-dev libkf6windowsystem-dev qt6-declarative-dev
     ```
 
     **Arch:**
 
     ```shell
-    sudo pacman -Sy git cmake gcc qt6-base frameworkintegration kcolorscheme kconfig kwindowsystem
+    sudo pacman -Sy git cmake gcc qt6-base frameworkintegration kcolorscheme kconfig kwindowsystem qt6-declarative
     ```
 
 2.  **Clone the repository**

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -64,11 +64,13 @@ void Config::onSettingsChanged() {
     menuBgOpacity = settings->menuOpacity();
     menuBlurBehind = settings->menuBlurBehind();
     spinVerticalControlsForNullWidgets = settings->spinBoxVerticalControls();
-    tabContentAlignment = (TabContentAlignment)settings->tabBarTabContentAlignment();
+    tabContentAlignment = static_cast<TabContentAlignment>(settings->tabBarTabContentAlignment());
     menuDrawOutline = settings->menuDrawOutline();
     groupBoxAltStyle = settings->groupBoxAltStyle();
+    windowDragMode = static_cast<WindowDragMode>(settings->windowDragMode());
 
-    emit configChanged();
+    emit
+    configChanged();
 }
 #endif
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -69,8 +69,7 @@ void Config::onSettingsChanged() {
     groupBoxAltStyle = settings->groupBoxAltStyle();
     windowDragMode = static_cast<WindowDragMode>(settings->windowDragMode());
 
-    emit
-    configChanged();
+    emit configChanged();
 }
 #endif
 

--- a/src/config.h
+++ b/src/config.h
@@ -16,6 +16,9 @@ class Config : public QObject {
     enum TabContentAlignment { Start,
                                IconStartTextCenter,
                                Center };
+    enum WindowDragMode { None,
+                          ToolbarOnly,
+                          Everywhere };
 
    public:
     Config(const Config&) = delete;
@@ -53,6 +56,7 @@ class Config : public QObject {
      */
    public:
     int cornerRadius = 12;  // for the elements that dont have their own corner radius
+    WindowDragMode windowDragMode = ToolbarOnly;
 
     static constexpr int smallArrowSize = 10;
     static constexpr int dolphinUrlNavigatorArrowSize = 12;  // the maximal size of the arrows in the dolphin url navigator bar, at the top, workaround - beacuse without this limit, they were too big

--- a/src/settings.kcfg
+++ b/src/settings.kcfg
@@ -76,5 +76,17 @@
             </tooltip>
             <default>false</default>
         </entry>
+        <entry name="WindowDragMode" type="Enum">
+            <label>From what areas to allow dragging windows</label>
+            <tooltip>
+
+            </tooltip>
+            <choices>
+                <choice name="None" />
+                <choice name="ToolbarOnly" />
+                <choice name="Everywhere" />
+            </choices>
+            <default>1</default> <!-- ToolbarOnly -->
+        </entry>
     </group>
 </kcfg>

--- a/src/settings.kcfg
+++ b/src/settings.kcfg
@@ -79,7 +79,7 @@
         <entry name="WindowDragMode" type="Enum">
             <label>From what areas to allow dragging windows</label>
             <tooltip>
-
+                This style supports dragging windows by their contents, by which parts of the windows should it be possible to drag them. 
             </tooltip>
             <choices>
                 <choice name="None" />

--- a/src/settings/settings_app.cpp
+++ b/src/settings/settings_app.cpp
@@ -32,6 +32,7 @@ SettingsApp::SettingsApp(QWidget* parent)
     connect(ui->tabAlignmentComboBox, &QComboBox::currentIndexChanged, this, &SettingsApp::widgetChanged);
     connect(ui->groupBoxAltStyleCheck, &QCheckBox::clicked, this, &SettingsApp::widgetChanged);
     connect(ui->menuOpacitySlider, &QSlider::valueChanged, this, [this](int value) { ui->blurBehindMenusCheck->setEnabled(HAS_KWINDOWSYSTEM && value < 255); });
+    connect(ui->windowDragModeCombo, &QComboBox::currentIndexChanged, this, &SettingsApp::widgetChanged);
 
     loadFromSettings();
 }
@@ -53,6 +54,7 @@ void SettingsApp::save() {
     settings->setTabBarTabContentAlignment(ui->tabAlignmentComboBox->currentIndex());
     settings->setMenuDrawOutline(ui->menuOutlineCheck->isChecked());
     settings->setGroupBoxAltStyle(ui->groupBoxAltStyleCheck->isChecked());
+    settings->setWindowDragMode(ui->windowDragModeCombo->currentIndex());
     settings->save();
 #if HAS_DBUS
     auto msg = QDBusMessage::createSignal(
@@ -75,6 +77,7 @@ void SettingsApp::loadFromSettings() {
     ui->tabAlignmentComboBox->setCurrentIndex(settings->tabBarTabContentAlignment());
     ui->menuOutlineCheck->setChecked(settings->menuDrawOutline());
     ui->groupBoxAltStyleCheck->setChecked(settings->groupBoxAltStyle());
+    ui->windowDragModeCombo->setCurrentIndex(settings->windowDragMode());
 }
 
 SettingsApp::~SettingsApp() {

--- a/src/settings/settings_app.ui
+++ b/src/settings/settings_app.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
-    <height>600</height>
+    <width>630</width>
+    <height>650</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -139,6 +139,32 @@
         <property name="text">
          <string/>
         </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>WIndow drag mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QComboBox" name="windowDragModeCombo">
+        <item>
+         <property name="text">
+          <string>Drag from titlebar only</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Drag from TItlebar, Menubars or Toolbars</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Drag from all empty areas</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -2068,7 +2068,11 @@ void Style::drawPrimitive(QStyle::PrimitiveElement element, const QStyleOption* 
 }
 
 void Style::polish(QWidget* widget) {
-    SuperStyle::polish(widget);
+    if (!widget)
+        return;
+
+    windowMgr.registerWidget(widget);
+
     if (widget->inherits("QAbstractButton") ||
         widget->inherits("QTabBar") ||
         widget->inherits("QScrollBar") ||
@@ -2126,6 +2130,7 @@ void Style::polish(QWidget* widget) {
         blurMgr.registerWidget(widget);
     }
 #endif
+    SuperStyle::polish(widget);
 }
 
 void Style::unpolish(QWidget* widget) {

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -13,6 +13,10 @@
 #include <QStyleFactory>
 #include <QtMath>
 
+#if HAS_QTQUICK
+#include <QQuickItem>
+#endif
+
 #include "animation_manager.h"
 #include "colors.h"
 #include "style.h"
@@ -31,6 +35,8 @@ Style::~Style() {
 
 void Style::drawComplexControl(QStyle::ComplexControl control, const QStyleOptionComplex* opt, QPainter* p, const QWidget* widget) const {
     Lilac::State state(opt->state);  // this had to be defined as Lilac::State because just State would conflict with State from QStyle
+    installOnQuickItems(opt->styleObject);
+
     switch (control) {
         case CC_ScrollBar:
             if (const auto* bar = qstyleoption_cast<const QStyleOptionSlider*>(opt)) {
@@ -445,6 +451,8 @@ void Style::drawComplexControl(QStyle::ComplexControl control, const QStyleOptio
 
 void Style::drawControl(QStyle::ControlElement element, const QStyleOption* opt, QPainter* p, const QWidget* widget) const {
     Lilac::State state(opt->state);
+    installOnQuickItems(opt->styleObject);
+
 #if HAS_KSTYLE
     // kstyle_CE_CapacityBar is not part of QStyle::ControlElement, but is acquired from kstyle, so it cannot be used in the switch
     if (kstyle_CE_CapacityBar && element == kstyle_CE_CapacityBar) {
@@ -2134,6 +2142,8 @@ void Style::polish(QWidget* widget) {
 }
 
 void Style::unpolish(QWidget* widget) {
+    windowMgr.unregisterWidget(widget);
+
     if (widget->inherits("QAbstractButton") ||
         widget->inherits("QTabBar") ||
         widget->inherits("QScrollBar") ||
@@ -3839,6 +3849,14 @@ void Style::drawDropShadow(QPainter* p, const QRectF& rect, const qreal cornerRa
     p->fillRect(centerRect, color);
 
     p->restore();
+}
+
+inline void Style::installOnQuickItems(QObject* object) const {
+#if HAS_QTQUICK
+    if (auto quickItem = qobject_cast<QQuickItem*>(object)) {
+        windowMgr.registerQuickItem(quickItem);
+    }
+#endif
 }
 
 }  // namespace Lilac

--- a/src/style.h
+++ b/src/style.h
@@ -57,7 +57,7 @@ class Style : public SuperStyle {
    protected:
     const Lilac::Config& config;  // conveninece variable so Config::Get() does not have to be always called;
     mutable Lilac::AnimationManager animationMgr;
-    mutable Lilac::WindowManager windowMgr; // for dragging windows by their contents
+    mutable Lilac::WindowManager windowMgr;  // for dragging windows by their contents
 #if HAS_KWINDOWSYSTEM
     mutable Lilac::BlurManager blurMgr;
 #endif
@@ -75,6 +75,7 @@ class Style : public SuperStyle {
     static bool tabIsHorizontal(const QTabBar::Shape& tabShape);
     QRect tabBarTabIconRect(const QStyleOptionTab* tab, const Lilac::State& state, const QRect& textRect) const;
     static void drawDropShadow(QPainter* p, const QRectF& rect, const qreal cornerRadius, const qreal blurRadius, const QPointF offset, const QColor color);
+    inline void installOnQuickItems(QObject* object) const;  // does something only if HAS_QTQUICK
 
    private:
 #if HAS_KSTYLE

--- a/src/style.h
+++ b/src/style.h
@@ -17,6 +17,7 @@
 #include "blur_manager.h"
 #include "config.h"
 #include "utils/state.h"
+#include "window_manager.h"
 
 namespace Lilac {
 
@@ -56,6 +57,7 @@ class Style : public SuperStyle {
    protected:
     const Lilac::Config& config;  // conveninece variable so Config::Get() does not have to be always called;
     mutable Lilac::AnimationManager animationMgr;
+    mutable Lilac::WindowManager windowMgr; // for dragging windows by their contents
 #if HAS_KWINDOWSYSTEM
     mutable Lilac::BlurManager blurMgr;
 #endif

--- a/src/window_manager.cpp
+++ b/src/window_manager.cpp
@@ -10,7 +10,7 @@
  */
 
 /*
-This file is taken from the Breeze project
+This file is originally from the Breeze style
 */
 
 #include <QComboBox>

--- a/src/window_manager.cpp
+++ b/src/window_manager.cpp
@@ -1,0 +1,783 @@
+/*
+ * breezewindowmanager.cpp
+ * pass some window mouse press/release/move event actions to window manager
+ * Largely inspired from BeSpin style
+ *
+ * SPDX-FileCopyrightText: 2007 Thomas Luebking <thomas.luebking@web.de>
+ * SPDX-FileCopyrightText: 2014 Hugo Pereira Da Costa <hugo.pereira@free.fr>
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+ */
+
+/*
+This file is taken from the Breeze project
+*/
+
+#include <QComboBox>
+#include <QDialog>
+#include <QDockWidget>
+#include <QGraphicsView>
+#include <QGroupBox>
+#include <QLabel>
+#include <QListView>
+#include <QMainWindow>
+#include <QMdiSubWindow>
+#include <QMenuBar>
+#include <QMouseEvent>
+#include <QProgressBar>
+#include <QScreen>
+#include <QScrollBar>
+#include <QStatusBar>
+#include <QStyle>
+#include <QStyleOptionGroupBox>
+#include <QTabBar>
+#include <QTabWidget>
+#include <QToolBar>
+#include <QToolButton>
+#include <QTreeView>
+
+#include <QTextStream>
+
+// needed to deal with device pixel ratio
+#include <QWindow>
+
+#include "config.h"
+#include "window_manager.h"
+
+#if LILAC_HAVE_QTQUICK
+// needed to enable dragging from QQuickWindows
+#include <QQuickRenderControl>
+#include <QQuickWindow>
+#endif
+
+namespace Util {
+template <class T>
+inline T makeT(std::initializer_list<typename T::key_type>&& reference) {
+    return T(std::move(reference));
+}
+}  // namespace Util
+
+namespace Lilac {
+//* provide application-wise event filter
+/**
+it us used to unlock dragging and make sure event look is properly restored
+after a drag has occurred
+*/
+class AppEventFilter : public QObject {
+   public:
+    //* constructor
+    explicit AppEventFilter(WindowManager* parent)
+        : QObject(parent), _parent(parent) {
+    }
+
+    //* event filter
+    bool eventFilter(QObject* object, QEvent* event) override {
+        if (event->type() == QEvent::MouseButtonRelease) {
+            // stop drag timer
+            if (_parent->_dragTimer.isActive()) {
+                _parent->resetDrag();
+            }
+
+            // unlock
+            if (_parent->isLocked()) {
+                _parent->setLocked(false);
+            }
+        }
+
+        if (!_parent->enabled()) {
+            return false;
+        }
+
+        /*
+        if a drag is in progress, the widget will not receive any event
+        we trigger on the first MouseMove or MousePress events that are received
+        by any widget in the application to detect that the drag is finished
+        */
+        if (_parent->_dragInProgress && _parent->_target && (event->type() == QEvent::MouseMove || event->type() == QEvent::MouseButtonPress)) {
+            return appMouseEvent(object, event);
+        }
+
+        return false;
+    }
+
+   protected:
+    //* application-wise event.
+    /** needed to catch end of XMoveResize events */
+    bool appMouseEvent(QObject*, QEvent* event) {
+        Q_UNUSED(event);
+
+        /*
+        post some mouseRelease event to the target, in order to counterbalance
+        the mouse press that triggered the drag. Note that it triggers a resetDrag
+        */
+        QMouseEvent mouseEvent(QEvent::MouseButtonRelease, _parent->_dragPoint, QCursor::pos(), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+        qApp->sendEvent(_parent->_target.data(), &mouseEvent);
+
+        return false;
+    }
+
+   private:
+    // lifetime: _parent IS the parent QObject. When it is destructed, so is the filter.
+    WindowManager* _parent = nullptr;
+};
+
+//_____________________________________________________________
+WindowManager::WindowManager()
+    : QObject() {
+    // install application wise event filter
+    _appEventFilter = new AppEventFilter(this);
+    qApp->installEventFilter(_appEventFilter);
+    connect(&Config::get(), &Config::configChanged, this, &WindowManager::initialize);
+}
+
+//_____________________________________________________________
+void WindowManager::initialize() {
+    const Config::WindowDragMode dragMode = Config::get().windowDragMode;
+    setEnabled(dragMode != Config::None);
+    setDragMode(dragMode);
+    setDragDistance(QApplication::startDragDistance());
+    setDragDelay(QApplication::startDragTime());
+
+    initializeWhiteList();
+    initializeBlackList();
+}
+
+//_____________________________________________________________
+void WindowManager::registerWidget(QWidget* widget) {
+    if (isBlackListed(widget) || isDraggable(widget) || widget->inherits("QQuickWidget")) {
+        /*
+        install filter for draggable widgets.
+        also install filter for blacklisted widgets
+        to be able to catch the relevant events and prevent
+        the drag to happen
+        */
+        widget->removeEventFilter(this);
+        widget->installEventFilter(this);
+    }
+}
+
+#if LILAC_HAVE_QTQUICK
+//_____________________________________________________________
+void WindowManager::registerQuickItem(QQuickItem* item) {
+    if (!item) {
+        return;
+    }
+
+    if (auto window = item->window()) {
+        auto contentItem = window->contentItem();
+        contentItem->setAcceptedMouseButtons(Qt::LeftButton);
+        contentItem->removeEventFilter(this);
+        contentItem->installEventFilter(this);
+    }
+}
+#endif
+
+//_____________________________________________________________
+void WindowManager::unregisterWidget(QWidget* widget) {
+    if (widget) {
+        widget->removeEventFilter(this);
+    }
+}
+
+//_____________________________________________________________
+void WindowManager::initializeWhiteList() {
+    _whiteList = Util::makeT<ExceptionSet>({ExceptionId(QStringLiteral("MplayerWindow")),
+                                            ExceptionId(QStringLiteral("ViewSliders@kmix")),
+                                            ExceptionId(QStringLiteral("Sidebar_Widget@konqueror"))});
+
+    const auto windowDragWhiteList = QStringList();  // StyleConfigData::windowDragWhiteList();
+    for (const QString& exception : windowDragWhiteList) {
+        ExceptionId id(exception);
+        if (!id.className().isEmpty()) {
+            _whiteList.insert(ExceptionId(exception));
+        }
+    }
+}
+
+//_____________________________________________________________
+void WindowManager::initializeBlackList() {
+    _blackList = Util::makeT<ExceptionSet>(
+        {ExceptionId(QStringLiteral("CustomTrackView@kdenlive")),
+         ExceptionId(QStringLiteral("MuseScore")),
+         ExceptionId(QStringLiteral("KGameCanvasWidget"))});
+
+    const auto windowDragBlackList = QStringList();  //  StyleConfigData::windowDragBlackList();
+    for (const QString& exception : windowDragBlackList) {
+        ExceptionId id(exception);
+        if (!id.className().isEmpty()) {
+            _blackList.insert(ExceptionId(exception));
+        }
+    }
+}
+
+//_____________________________________________________________
+bool WindowManager::eventFilter(QObject* object, QEvent* event) {
+    if (!enabled()) {
+        return false;
+    }
+
+    switch (event->type()) {
+        case QEvent::MouseButtonPress:
+            return mousePressEvent(object, event);
+            break;
+
+        case QEvent::MouseMove:
+            if (object == _target.data()
+#if LILAC_HAVE_QTQUICK
+                || object == _quickTarget.data()
+#endif
+            ) {
+                return mouseMoveEvent(object, event);
+            }
+            break;
+
+        case QEvent::MouseButtonRelease:
+            if (_target
+#if LILAC_HAVE_QTQUICK
+                || _quickTarget
+#endif
+            ) {
+                return mouseReleaseEvent(object, event);
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    return false;
+}
+
+//_____________________________________________________________
+void WindowManager::timerEvent(QTimerEvent* event) {
+    if (event->timerId() == _dragTimer.timerId()) {
+        _dragTimer.stop();
+        setLocked(false);
+        if (_target) {
+            startDrag(_target.data()->window()->windowHandle());
+        }
+#if LILAC_HAVE_QTQUICK
+        else if (_quickTarget) {
+            _quickTarget.data()->ungrabMouse();
+            startDrag(_quickTarget.data()->window());
+        }
+#endif
+        resetDrag();
+    } else {
+        return QObject::timerEvent(event);
+    }
+}
+
+//_____________________________________________________________
+bool WindowManager::mousePressEvent(QObject* object, QEvent* event) {
+    // cast event and check buttons/modifiers
+    auto mouseEvent = static_cast<QMouseEvent*>(event);
+    if (mouseEvent->source() != Qt::MouseEventNotSynthesized) {
+        return false;
+    }
+    if (!(mouseEvent->modifiers() == Qt::NoModifier && mouseEvent->button() == Qt::LeftButton)) {
+        return false;
+    }
+
+    // If we are in a QQuickWidget we don't want to ever do dragging from a qwidget in the
+    // hierarchy, but only from an internal item, if any. If any event handler will manage
+    // the event, we don't want the drag to start
+    if (object->inherits("QQuickWidget")) {
+        _eventInQQuickWidget = true;
+        event->setAccepted(false);
+        return false;
+    } else {
+        _eventInQQuickWidget = false;
+    }
+
+    // check lock
+    if (isLocked()) {
+        return false;
+    } else {
+        setLocked(true);
+    }
+
+#if LILAC_HAVE_QTQUICK
+    // check QQuickItem - we can immediately start drag, because QQuickWindow's contentItem
+    // only receives mouse events that weren't handled by children
+    if (auto item = qobject_cast<QQuickItem*>(object)) {
+        _quickTarget = item;
+        _dragPoint = mouseEvent->pos();
+        _globalDragPoint =
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            mouseEvent->globalPosition().toPoint();
+#else
+            mouseEvent->globalPos();
+#endif
+
+        if (_dragTimer.isActive()) {
+            _dragTimer.stop();
+        }
+        _dragTimer.start(_dragDelay, this);
+
+        return true;
+    }
+#endif
+
+    if (_eventInQQuickWidget) {
+        event->setAccepted(true);
+        return false;
+    }
+    _eventInQQuickWidget = false;
+
+    // cast to widget
+    auto widget = static_cast<QWidget*>(object);
+
+    // check if widget can be dragged from current position
+    if (isBlackListed(widget) || !canDrag(widget)) {
+        return false;
+    }
+
+    // retrieve widget's child at event position
+    auto position(mouseEvent->pos());
+    auto child = widget->childAt(position);
+    if (!canDrag(widget, child, position)) {
+        return false;
+    }
+
+    // save target and drag point
+    _target = widget;
+    _dragPoint = position;
+    _globalDragPoint =
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        mouseEvent->globalPosition().toPoint();
+#else
+        mouseEvent->globalPos();
+#endif
+    _dragAboutToStart = true;
+
+    // send a move event to the current child with same position
+    // if received, it is caught to actually start the drag
+    auto localPoint(_dragPoint);
+    if (child) {
+        localPoint = child->mapFrom(widget, localPoint);
+    } else {
+        child = widget;
+    }
+    QMouseEvent localMouseEvent(QEvent::MouseMove,
+                                localPoint,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+                                QCursor::pos(),
+#endif
+                                Qt::NoButton,
+                                Qt::LeftButton,
+                                Qt::NoModifier);
+    localMouseEvent.setTimestamp(mouseEvent->timestamp());
+    qApp->sendEvent(child, &localMouseEvent);
+
+    // never eat event
+    return false;
+}
+
+//_____________________________________________________________
+bool WindowManager::mouseMoveEvent(QObject* object, QEvent* event) {
+    Q_UNUSED(object);
+
+    // stop timer
+    if (_dragTimer.isActive()) {
+        _dragTimer.stop();
+    }
+
+    // cast event and check drag distance
+    auto mouseEvent = static_cast<QMouseEvent*>(event);
+    if (mouseEvent->source() != Qt::MouseEventNotSynthesized) {
+        return false;
+    }
+    auto eventPos =
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        mouseEvent->globalPosition().toPoint();
+#else
+        mouseEvent->globalPos();
+#endif
+    if (!_dragInProgress) {
+        if (_dragAboutToStart) {
+            if (mouseEvent->pos() == _dragPoint) {
+                // start timer,
+                _dragAboutToStart = false;
+                if (_dragTimer.isActive()) {
+                    _dragTimer.stop();
+                }
+                _dragTimer.start(_dragDelay, this);
+
+            } else {
+                resetDrag();
+            }
+
+        } else if (QPoint(eventPos - _globalDragPoint).manhattanLength() >= _dragDistance) {
+            _dragTimer.start(0, this);
+        }
+
+        return true;
+
+    } else {
+        return false;
+    }
+}
+
+//_____________________________________________________________
+bool WindowManager::mouseReleaseEvent(QObject* object, QEvent* event) {
+    Q_UNUSED(object);
+    Q_UNUSED(event);
+    resetDrag();
+    return false;
+}
+
+//_____________________________________________________________
+bool WindowManager::isDraggable(QWidget* widget) {
+    // check widget
+    if (!widget) {
+        return false;
+    }
+
+    // accepted default types
+    if ((qobject_cast<QDialog*>(widget) && widget->isWindow()) || (qobject_cast<QMainWindow*>(widget) && widget->isWindow()) || qobject_cast<QGroupBox*>(widget)) {
+        return true;
+    }
+
+    // more accepted types, provided they are not dock widget titles
+    if ((qobject_cast<QMenuBar*>(widget) || qobject_cast<QTabBar*>(widget) || qobject_cast<QStatusBar*>(widget) || qobject_cast<QToolBar*>(widget)) && !isDockWidgetTitle(widget)) {
+        return true;
+    }
+
+    if (widget->inherits("KScreenSaver") && widget->inherits("KCModule")) {
+        return true;
+    }
+
+    if (isWhiteListed(widget)) {
+        return true;
+    }
+
+    // flat toolbuttons
+    if (auto toolButton = qobject_cast<QToolButton*>(widget)) {
+        if (toolButton->autoRaise()) {
+            return true;
+        }
+    }
+
+    // viewports
+    /*
+    one needs to check that
+    1/ the widget parent is a scrollarea
+    2/ it matches its parent viewport
+    3/ the parent is not blacklisted
+    */
+    if (auto listView = qobject_cast<QListView*>(widget->parentWidget())) {
+        if (listView->viewport() == widget && !isBlackListed(listView)) {
+            return true;
+        }
+    }
+
+    if (auto treeView = qobject_cast<QTreeView*>(widget->parentWidget())) {
+        if (treeView->viewport() == widget && !isBlackListed(treeView)) {
+            return true;
+        }
+    }
+
+    /*
+    catch labels in status bars.
+    this is because of kstatusbar
+    who captures buttonPress/release events
+    */
+    if (auto label = qobject_cast<QLabel*>(widget)) {
+        if (label->textInteractionFlags().testFlag(Qt::TextSelectableByMouse)) {
+            return false;
+        }
+
+        QWidget* parent = label->parentWidget();
+        while (parent) {
+            if (qobject_cast<QStatusBar*>(parent)) {
+                return true;
+            }
+            parent = parent->parentWidget();
+        }
+    }
+
+    return false;
+}
+
+//_____________________________________________________________
+bool WindowManager::isBlackListed(QWidget* widget) {
+    // check against noAnimations property
+    // const auto propertyValue(widget->property(PropertyNames::noWindowGrab));
+    // if (propertyValue.isValid() && propertyValue.toBool()) {
+    //     return true;
+    // }
+
+    // list-based blacklisted widgets
+    const auto appName(qApp->applicationName());
+    for (const ExceptionId& id : std::as_const(_blackList)) {
+        if (!id.appName().isEmpty() && id.appName() != appName) {
+            continue;
+        }
+        if (id.className() == QStringLiteral("*") && !id.appName().isEmpty()) {
+            // if application name matches and all classes are selected
+            // disable the grabbing entirely
+            setEnabled(false);
+            return true;
+        }
+        if (widget->inherits(id.className().toLatin1().data())) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+//_____________________________________________________________
+bool WindowManager::isWhiteListed(QWidget* widget) const {
+    const auto appName(qApp->applicationName());
+    for (const ExceptionId& id : std::as_const(_whiteList)) {
+        if (!(id.appName().isEmpty() || id.appName() == appName)) {
+            continue;
+        }
+        if (widget->inherits(id.className().toLatin1().data())) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+//_____________________________________________________________
+bool WindowManager::canDrag(QWidget* widget) {
+    // check if enabled
+    if (!enabled()) {
+        return false;
+    }
+
+    // assume isDraggable widget is already passed
+    // check some special cases where drag should not be effective
+
+    // check mouse grabber
+    if (QWidget::mouseGrabber()) {
+        return false;
+    }
+
+    /*
+    check cursor shape.
+    Assume that a changed cursor means that some action is in progress
+    and should prevent the drag
+    */
+    if (widget->cursor().shape() != Qt::ArrowCursor) {
+        return false;
+    }
+
+    // accept
+    return true;
+}
+
+//_____________________________________________________________
+bool WindowManager::canDrag(QWidget* widget, QWidget* child, const QPoint& position) {
+    // retrieve child at given position and check cursor again
+    if (child && child->cursor().shape() != Qt::ArrowCursor) {
+        return false;
+    }
+
+    /*
+    check against children from which drag should never be enabled,
+    even if mousePress/Move has been passed to the parent
+    */
+    if (child && (qobject_cast<QComboBox*>(child) || qobject_cast<QProgressBar*>(child) || qobject_cast<QScrollBar*>(child))) {
+        return false;
+    }
+
+    // tool buttons
+    if (auto toolButton = qobject_cast<QToolButton*>(widget)) {
+        if (dragMode() == Config::WindowDragMode::ToolbarOnly && !qobject_cast<QToolBar*>(widget->parentWidget())) {
+            return false;
+        }
+        return toolButton->autoRaise() && !toolButton->isEnabled();
+    }
+
+    // check menubar
+    if (auto menuBar = qobject_cast<QMenuBar*>(widget)) {
+        // do not drag from menubars embedded in Mdi windows
+        if (findParent<QMdiSubWindow*>(widget)) {
+            return false;
+        }
+
+        // check if there is an active action
+        if (menuBar->activeAction() && menuBar->activeAction()->isEnabled()) {
+            return false;
+        }
+
+        // check if action at position exists and is enabled
+        if (auto action = menuBar->actionAt(position)) {
+            if (action->isSeparator()) {
+                return true;
+            }
+            if (action->isEnabled()) {
+                return false;
+            }
+        }
+
+        // return true in all other cases
+        return true;
+    }
+
+    /*
+    in MINIMAL mode, anything that has not been already accepted
+    and does not come from a toolbar is rejected
+    */
+    if (dragMode() == Config::WindowDragMode::ToolbarOnly) {
+        if (qobject_cast<QToolBar*>(widget)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /* following checks are relevant only for WD_FULL mode */
+
+    // tabbar. Make sure no tab is under the cursor
+    if (auto tabBar = qobject_cast<QTabBar*>(widget)) {
+        return tabBar->tabAt(position) == -1;
+    }
+
+    /*
+    check groupboxes
+    prevent drag if unchecking grouboxes
+    */
+    if (auto groupBox = qobject_cast<QGroupBox*>(widget)) {
+        // non checkable group boxes are always ok
+        if (!groupBox->isCheckable()) {
+            return true;
+        }
+
+        // gather options to retrieve checkbox subcontrol rect
+        QStyleOptionGroupBox opt;
+        opt.initFrom(groupBox);
+        if (groupBox->isFlat()) {
+            opt.features |= QStyleOptionFrame::Flat;
+        }
+        opt.lineWidth = 1;
+        opt.midLineWidth = 0;
+        opt.text = groupBox->title();
+        opt.textAlignment = groupBox->alignment();
+        opt.subControls = (QStyle::SC_GroupBoxFrame | QStyle::SC_GroupBoxCheckBox);
+        if (!groupBox->title().isEmpty()) {
+            opt.subControls |= QStyle::SC_GroupBoxLabel;
+        }
+
+        opt.state |= (groupBox->isChecked() ? QStyle::State_On : QStyle::State_Off);
+
+        // check against groupbox checkbox
+        if (groupBox->style()->subControlRect(QStyle::CC_GroupBox, &opt, QStyle::SC_GroupBoxCheckBox, groupBox).contains(position)) {
+            return false;
+        }
+
+        // check against groupbox label
+        if (!groupBox->title().isEmpty() && groupBox->style()->subControlRect(QStyle::CC_GroupBox, &opt, QStyle::SC_GroupBoxLabel, groupBox).contains(position)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    // labels
+    if (auto label = qobject_cast<QLabel*>(widget)) {
+        if (label->textInteractionFlags().testFlag(Qt::TextSelectableByMouse)) {
+            return false;
+        }
+    }
+
+    // abstract item views
+    QAbstractItemView* itemView(nullptr);
+    if ((itemView = qobject_cast<QListView*>(widget->parentWidget())) || (itemView = qobject_cast<QTreeView*>(widget->parentWidget()))) {
+        if (widget == itemView->viewport()) {
+            // QListView
+            if (itemView->frameShape() != QFrame::NoFrame) {
+                return false;
+            } else if (itemView->selectionMode() != QAbstractItemView::NoSelection && itemView->selectionMode() != QAbstractItemView::SingleSelection && itemView->model() && itemView->model()->rowCount()) {
+                return false;
+            } else if (itemView->model() && itemView->indexAt(position).isValid()) {
+                return false;
+            }
+        }
+
+    } else if ((itemView = qobject_cast<QAbstractItemView*>(widget->parentWidget()))) {
+        if (widget == itemView->viewport()) {
+            // QAbstractItemView
+            if (itemView->frameShape() != QFrame::NoFrame) {
+                return false;
+            } else if (itemView->indexAt(position).isValid()) {
+                return false;
+            }
+        }
+
+    } else if (auto graphicsView = qobject_cast<QGraphicsView*>(widget->parentWidget())) {
+        if (widget == graphicsView->viewport()) {
+            // QGraphicsView
+            if (graphicsView->frameShape() != QFrame::NoFrame) {
+                return false;
+            } else if (graphicsView->dragMode() != QGraphicsView::NoDrag) {
+                return false;
+            } else if (graphicsView->itemAt(position)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+//____________________________________________________________
+void WindowManager::resetDrag() {
+    _target.clear();
+#if LILAC_HAVE_QTQUICK
+    _quickTarget.clear();
+#endif
+    if (_dragTimer.isActive()) {
+        _dragTimer.stop();
+    }
+    _dragPoint = QPoint();
+    _globalDragPoint = QPoint();
+    _dragAboutToStart = false;
+    _dragInProgress = false;
+}
+
+//____________________________________________________________
+void WindowManager::startDrag(QWindow* window) {
+    if (!(enabled() && window)) {
+        return;
+    }
+    if (QWidget::mouseGrabber()) {
+        return;
+    }
+
+#if LILAC_HAVE_QTQUICK
+    if (_quickTarget) {
+        if (QQuickWindow* qw = qobject_cast<QQuickWindow*>(window)) {
+            QWindow* renderWindow = QQuickRenderControl::renderWindowFor(qw);
+            if (renderWindow) {
+                _dragInProgress = renderWindow->startSystemMove();
+            } else {
+                _dragInProgress = window->startSystemMove();
+            }
+        }
+    } else
+#endif
+    {
+        _dragInProgress = window->startSystemMove();
+    }
+}
+
+//____________________________________________________________
+bool WindowManager::isDockWidgetTitle(const QWidget* widget) const {
+    if (!widget) {
+        return false;
+    }
+    if (auto dockWidget = qobject_cast<const QDockWidget*>(widget->parent())) {
+        return widget == dockWidget->titleBarWidget();
+
+    } else {
+        return false;
+    }
+}
+
+}  // namespace Lilac

--- a/src/window_manager.cpp
+++ b/src/window_manager.cpp
@@ -44,7 +44,7 @@ This file is taken from the Breeze project
 #include "config.h"
 #include "window_manager.h"
 
-#if LILAC_HAVE_QTQUICK
+#if HAS_QTQUICK
 // needed to enable dragging from QQuickWindows
 #include <QQuickRenderControl>
 #include <QQuickWindow>
@@ -156,7 +156,7 @@ void WindowManager::registerWidget(QWidget* widget) {
     }
 }
 
-#if LILAC_HAVE_QTQUICK
+#if HAS_QTQUICK
 //_____________________________________________________________
 void WindowManager::registerQuickItem(QQuickItem* item) {
     if (!item) {
@@ -223,7 +223,7 @@ bool WindowManager::eventFilter(QObject* object, QEvent* event) {
 
         case QEvent::MouseMove:
             if (object == _target.data()
-#if LILAC_HAVE_QTQUICK
+#if HAS_QTQUICK
                 || object == _quickTarget.data()
 #endif
             ) {
@@ -233,7 +233,7 @@ bool WindowManager::eventFilter(QObject* object, QEvent* event) {
 
         case QEvent::MouseButtonRelease:
             if (_target
-#if LILAC_HAVE_QTQUICK
+#if HAS_QTQUICK
                 || _quickTarget
 #endif
             ) {
@@ -256,7 +256,7 @@ void WindowManager::timerEvent(QTimerEvent* event) {
         if (_target) {
             startDrag(_target.data()->window()->windowHandle());
         }
-#if LILAC_HAVE_QTQUICK
+#if HAS_QTQUICK
         else if (_quickTarget) {
             _quickTarget.data()->ungrabMouse();
             startDrag(_quickTarget.data()->window());
@@ -297,18 +297,13 @@ bool WindowManager::mousePressEvent(QObject* object, QEvent* event) {
         setLocked(true);
     }
 
-#if LILAC_HAVE_QTQUICK
+#if HAS_QTQUICK
     // check QQuickItem - we can immediately start drag, because QQuickWindow's contentItem
     // only receives mouse events that weren't handled by children
     if (auto item = qobject_cast<QQuickItem*>(object)) {
         _quickTarget = item;
         _dragPoint = mouseEvent->pos();
-        _globalDragPoint =
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            mouseEvent->globalPosition().toPoint();
-#else
-            mouseEvent->globalPos();
-#endif
+        _globalDragPoint = mouseEvent->globalPosition().toPoint();
 
         if (_dragTimer.isActive()) {
             _dragTimer.stop();
@@ -343,12 +338,7 @@ bool WindowManager::mousePressEvent(QObject* object, QEvent* event) {
     // save target and drag point
     _target = widget;
     _dragPoint = position;
-    _globalDragPoint =
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        mouseEvent->globalPosition().toPoint();
-#else
-        mouseEvent->globalPos();
-#endif
+    _globalDragPoint = mouseEvent->globalPosition().toPoint();
     _dragAboutToStart = true;
 
     // send a move event to the current child with same position
@@ -361,9 +351,7 @@ bool WindowManager::mousePressEvent(QObject* object, QEvent* event) {
     }
     QMouseEvent localMouseEvent(QEvent::MouseMove,
                                 localPoint,
-#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
                                 QCursor::pos(),
-#endif
                                 Qt::NoButton,
                                 Qt::LeftButton,
                                 Qt::NoModifier);
@@ -388,12 +376,8 @@ bool WindowManager::mouseMoveEvent(QObject* object, QEvent* event) {
     if (mouseEvent->source() != Qt::MouseEventNotSynthesized) {
         return false;
     }
-    auto eventPos =
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        mouseEvent->globalPosition().toPoint();
-#else
-        mouseEvent->globalPos();
-#endif
+    auto eventPos = mouseEvent->globalPosition().toPoint();
+
     if (!_dragInProgress) {
         if (_dragAboutToStart) {
             if (mouseEvent->pos() == _dragPoint) {
@@ -729,7 +713,7 @@ bool WindowManager::canDrag(QWidget* widget, QWidget* child, const QPoint& posit
 //____________________________________________________________
 void WindowManager::resetDrag() {
     _target.clear();
-#if LILAC_HAVE_QTQUICK
+#if HAS_QTQUICK
     _quickTarget.clear();
 #endif
     if (_dragTimer.isActive()) {
@@ -750,7 +734,7 @@ void WindowManager::startDrag(QWindow* window) {
         return;
     }
 
-#if LILAC_HAVE_QTQUICK
+#if HAS_QTQUICK
     if (_quickTarget) {
         if (QQuickWindow* qw = qobject_cast<QQuickWindow*>(window)) {
             QWindow* renderWindow = QQuickRenderControl::renderWindowFor(qw);

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -5,7 +5,7 @@
  */
 
 /*
-This file is taken from the Breeze project
+This file is originally from the Breeze style
 */
 
 #pragma once

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -19,7 +19,7 @@ This file is taken from the Breeze project
 #include <QString>
 #include <QWidget>
 
-#if LILAC_HAVE_QTQUICK
+#if HAS_QTQUICK
 #include <QQuickItem>
 #endif
 
@@ -42,7 +42,7 @@ class WindowManager : public QObject {
     //* register widget
     void registerWidget(QWidget*);
 
-#if LILAC_HAVE_QTQUICK
+#if HAS_QTQUICK
     //* register quick item
     void registerQuickItem(QQuickItem*);
 #endif
@@ -237,8 +237,8 @@ class WindowManager : public QObject {
     /** Weak pointer is used in case the target gets deleted while drag is in progress */
     QPointer<QWidget> _target;
 
-#if LILAC_HAVE_QTQUICK
-    WeakPointer<QQuickItem> _quickTarget;
+#if HAS_QTQUICK
+    QPointer<QQuickItem> _quickTarget;
 #endif
 
     //* true if drag is about to start

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -1,0 +1,283 @@
+/*
+ * SPDX-FileCopyrightText: 2014 Hugo Pereira Da Costa <hugo.pereira@free.fr>
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/*
+This file is taken from the Breeze project
+*/
+
+#pragma once
+
+#include <QApplication>
+#include <QBasicTimer>
+#include <QEvent>
+#include <QObject>
+#include <QPointer>
+#include <QSet>
+#include <QString>
+#include <QWidget>
+
+#if LILAC_HAVE_QTQUICK
+#include <QQuickItem>
+#endif
+
+#include "config.h"
+
+namespace Lilac {
+class AppEventFilter;
+
+class WindowManager : public QObject {
+    Q_OBJECT
+
+   public:
+    //* constructor
+    explicit WindowManager();
+
+    //* initialize
+    /** read relevant options from config */
+    void initialize();
+
+    //* register widget
+    void registerWidget(QWidget*);
+
+#if LILAC_HAVE_QTQUICK
+    //* register quick item
+    void registerQuickItem(QQuickItem*);
+#endif
+
+    //* unregister widget
+    void unregisterWidget(QWidget*);
+
+    //* event filter [reimplemented]
+    bool eventFilter(QObject*, QEvent*) override;
+
+   protected:
+    //* timer event,
+    /** used to start drag if button is pressed for a long enough time */
+    void timerEvent(QTimerEvent*) override;
+
+    //* mouse press event
+    bool mousePressEvent(QObject*, QEvent*);
+
+    //* mouse move event
+    bool mouseMoveEvent(QObject*, QEvent*);
+
+    //* mouse release event
+    bool mouseReleaseEvent(QObject*, QEvent*);
+
+    //*@name configuration
+    //@{
+
+    //* enable state
+    bool enabled() const {
+        return _enabled;
+    }
+
+    //* enable state
+    void setEnabled(bool value) {
+        _enabled = value;
+    }
+
+    //* drag mode
+    int dragMode() const {
+        return _dragMode;
+    }
+
+    //* drag mode
+    void setDragMode(int value) {
+        _dragMode = value;
+    }
+
+    //* drag distance (pixels)
+    void setDragDistance(int value) {
+        _dragDistance = value;
+    }
+
+    //* drag delay (msec)
+    void setDragDelay(int value) {
+        _dragDelay = value;
+    }
+
+    //* set list of whiteListed widgets
+    /**
+    white list is read from options and is used to adjust
+    per-app window dragging issues
+    */
+    void initializeWhiteList();
+
+    //* set list of blackListed widgets
+    /**
+    black list is read from options and is used to adjust
+    per-app window dragging issues
+    */
+    void initializeBlackList();
+
+    //@}
+
+    //* returns true if widget is draggable
+    bool isDraggable(QWidget*);
+
+    //* returns true if widget is draggable
+    bool isBlackListed(QWidget*);
+
+    //* returns true if widget is draggable
+    bool isWhiteListed(QWidget*) const;
+
+    //* returns true if drag can be started from current widget
+    bool canDrag(QWidget*);
+
+    //* returns true if drag can be started from current widget and position
+    /** child at given position is passed as second argument */
+    bool canDrag(QWidget*, QWidget*, const QPoint&);
+
+    //* reset drag
+    void resetDrag();
+
+    //* start drag
+    void startDrag(QWindow*);
+
+    //* utility function
+    bool isDockWidgetTitle(const QWidget*) const;
+
+    //*@name lock
+    //@{
+
+    void setLocked(bool value) {
+        _locked = value;
+    }
+
+    //* lock
+    bool isLocked() const {
+        return _locked;
+    }
+
+    //@}
+
+    //* returns first widget matching given class, or nullptr if none
+    template <typename T>
+    T findParent(const QWidget*) const;
+
+   private:
+    //* enability
+    bool _enabled = true;
+
+    //* drag mode
+    int _dragMode = Config::WindowDragMode::Everywhere;
+
+    //* drag distance
+    /** this is copied from kwin::geometry */
+    int _dragDistance = QApplication::startDragDistance();
+
+    //* drag delay
+    /** this is copied from kwin::geometry */
+    int _dragDelay = QApplication::startDragTime();
+
+    //* wrapper for exception id
+    class ExceptionId {
+       public:
+        //* constructor
+        explicit ExceptionId(const QString& value) {
+            const QStringList args(value.split(QChar::fromLatin1('@')));
+            if (args.isEmpty()) {
+                return;
+            }
+            _exception.second = args[0].trimmed();
+            if (args.size() > 1) {
+                _exception.first = args[1].trimmed();
+            }
+        }
+
+        const QString& appName() const {
+            return _exception.first;
+        }
+
+        const QString& className() const {
+            return _exception.second;
+        }
+
+       private:
+        QPair<QString, QString> _exception;
+
+        friend size_t qHash(const ExceptionId& value, size_t seed = 0) {
+            return qHash(value._exception, seed);
+        }
+
+        friend bool operator==(const ExceptionId& lhs, const ExceptionId& rhs) {
+            return lhs._exception == rhs._exception;
+        }
+    };
+
+    //* exception set
+    using ExceptionSet = QSet<ExceptionId>;
+
+    //* list of white listed special widgets
+    /**
+    it is read from options and is used to adjust
+    per-app window dragging issues
+    */
+    ExceptionSet _whiteList;
+
+    //* list of black listed special widgets
+    /**
+    it is read from options and is used to adjust
+    per-app window dragging issues
+    */
+    ExceptionSet _blackList;
+
+    //* drag point
+    QPoint _dragPoint;
+    QPoint _globalDragPoint;
+
+    //* drag timer
+    QBasicTimer _dragTimer;
+
+    //* target being dragged
+    /** Weak pointer is used in case the target gets deleted while drag is in progress */
+    QPointer<QWidget> _target;
+
+#if LILAC_HAVE_QTQUICK
+    WeakPointer<QQuickItem> _quickTarget;
+#endif
+
+    //* true if drag is about to start
+    bool _dragAboutToStart = false;
+
+    //* true if drag is in progress
+    bool _dragInProgress = false;
+
+    //* true if drag is locked
+    bool _locked = false;
+
+    //* true if the event we are intercepting passed through a QQuickWidget.
+    /**In this case we shouldn't start a drag, because if it was to start, we would have done it in the event filter of a qquickwidget.
+     * Event handlers don't accept input events, but they do block QQuickItems to receive the event, so the event may have been
+     * managed by an handler and not blocked by the root qml item.
+     **/
+    bool _eventInQQuickWidget = false;
+
+    // lifetime: parented to this
+    //* application event filter
+    AppEventFilter* _appEventFilter = nullptr;
+
+    //* allow access of all private members to the app event filter
+    friend class AppEventFilter;
+};
+
+//____________________________________________________________________
+template <typename T>
+T WindowManager::findParent(const QWidget* widget) const {
+    if (!widget) {
+        return nullptr;
+    }
+    for (QWidget* parent = widget->parentWidget(); parent; parent = parent->parentWidget()) {
+        if (T cast = qobject_cast<T>(parent)) {
+            return cast;
+        }
+    }
+
+    return nullptr;
+}
+
+}  // namespace Lilac


### PR DESCRIPTION
Implement dragging windows by their contents.

The window_manager.cpp/.h are from the [Breeze style](https://invent.kde.org/plasma/breeze).

There is a new option in the settings to set the level of the window drag.

There is also a new optional dependency: `QtQuick`, used for dragging Qt Quick applications.